### PR TITLE
Use 45 minutes for timer

### DIFF
--- a/app/timer.js
+++ b/app/timer.js
@@ -7,7 +7,7 @@ var Persistence = require('./persistence');
 var Time = require('./time');
 
 var timerUpdateFrequency = 1000; // 1 second
-var matchTime = 40 * 60 * 1000;  // 40 minutes
+var matchTime = 45 * 60 * 1000;  // 40 minutes
 
 // Abstract representation of a Yugioh match timer.
 function Timer (spec) {


### PR DESCRIPTION
Konami now uses 45 minutes as the allotted time for rounds at all [Yugioh events](https://yugiohblog.konami.com/2023/05/tournament-policy-2-2/). Love your calculator, let's update the timer to reflect the new round times!